### PR TITLE
Dynamically determine if a file 'isKubernetes' based on filetype and 'Kind's in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ insert the schema like in the example below.
       yamlls = {
         yaml = {
           schemas = {
-            [require('kubernetes').yamlls_schema()] = "*.yaml",
+            kubernetes = require('kubernetes').yamlls_filetypes(),
+            [require('kubernetes').yamlls_schema()] = { "*.yaml", "*.yml" }
           }
         }
       }
@@ -87,17 +88,6 @@ This can be achieved like so: `kubectl get --raw /openapi/v2 | jq '.definitions'
 The `schema.json` is that `all.json` file that has the `oneOf`.
 To do this just get all iterate the `definitions.json` and add the appropriate entry into `schema.json`. To reference a local file use `file://<full path>#/definitions/...`.
 
-3. Patch the yaml language server.\ 
-Right now kubernetes support seems to be hardcoded into `yamlls`. Trying to use this generated schema without modifications will give out the error `Matches multiple schemas when only one must validate.`. The language server has an check to see if the current document is a kubernetes document and if so then ignore that error.
-```
-https://github.com/redhat-developer/yaml-language-server/blob/ed03cbf71ade29ea62b4bcac0d8952195fd6969d/src/languageservice/services/yamlValidation.ts#L122
-```
-But from what I could find the only way of having a document be a kubernetes document is if the uri of the schema file associated with that document is the hardcoded one.
-```
-https://github.com/redhat-developer/yaml-language-server/blob/main/src/languageservice/utils/schemaUrls.ts#L8
-```
-The language server has an option to use an http proxy and I initially tought that we could just make a proxy, then intercept any requests to that uri and return our own. But it turns out http proxies don't proxy individual requests and instead just forward the byte stream to another server and since the request for that uri will be made over httpt this option doesn't really work.
-
-So instead of doing any of that remove the check we can just remove the requirement for a document to be a kubernetes document and always ignore that error. Since the language server is written in javascript that turns out to be quite simple, it is just a string replacement.
+3. Patch the yaml language server.
 
 And thats it, now it works.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ insert the schema like in the example below.
       yamlls = {
         yaml = {
           schemas = {
-            kubernetes = require('kubernetes').yamlls_filetypes(),
-            [require('kubernetes').yamlls_schema()] = { "*.yaml", "*.yml" }
+            -- use this if you want to match all '*.yaml' files
+            [require('kubernetes').yamlls_schema()] = "*.yaml",
+            -- or this to only match '*.<resource>.yaml' files. ex: 'app.deployment.yaml', 'app.argocd.yaml', ...
+            [require('kubernetes').yamlls_schema()] = require('kubernetes').yamlls_filetypes()
           }
         }
       }
@@ -88,6 +90,17 @@ This can be achieved like so: `kubectl get --raw /openapi/v2 | jq '.definitions'
 The `schema.json` is that `all.json` file that has the `oneOf`.
 To do this just get all iterate the `definitions.json` and add the appropriate entry into `schema.json`. To reference a local file use `file://<full path>#/definitions/...`.
 
-3. Patch the yaml language server.
+3. Patch the yaml language server.\ 
+Right now kubernetes support seems to be hardcoded into `yamlls`. Trying to use this generated schema without modifications will give out the error `Matches multiple schemas when only one must validate.`. The language server has an check to see if the current document is a kubernetes document and if so then ignore that error.
+```
+https://github.com/redhat-developer/yaml-language-server/blob/ed03cbf71ade29ea62b4bcac0d8952195fd6969d/src/languageservice/services/yamlValidation.ts#L122
+```
+But from what I could find the only way of having a document be a kubernetes document is if the uri of the schema file associated with that document is the hardcoded one.
+```
+https://github.com/redhat-developer/yaml-language-server/blob/main/src/languageservice/utils/schemaUrls.ts#L8
+```
+The language server has an option to use an http proxy and I initially tought that we could just make a proxy, then intercept any requests to that uri and return our own. But it turns out http proxies don't proxy individual requests and instead just forward the byte stream to another server and since the request for that uri will be made over httpt this option doesn't really work.
+
+So instead of doing any of that remove the check we can just remove the requirement for a document to be a kubernetes document and always ignore that error. Since the language server is written in javascript that turns out to be quite simple, it is just a string replacement.
 
 And thats it, now it works.

--- a/lua/kubernetes/init.lua
+++ b/lua/kubernetes/init.lua
@@ -147,9 +147,10 @@ function M.yamlls_filetypes()
 	for _, k in ipairs(kinds) do
 		-- Grab last column
 		local kind = k:gsub(".* (%w+)$", "%1"):lower()
-
-		table.insert(filetypes, "*." .. kind .. ".yml")
-		table.insert(filetypes, "*." .. kind .. ".yaml")
+		if kind ~= "" then
+			table.insert(filetypes, "*." .. kind .. ".yml")
+			table.insert(filetypes, "*." .. kind .. ".yaml")
+		end
 	end
 	return filetypes
 end

--- a/lua/kubernetes/init.lua
+++ b/lua/kubernetes/init.lua
@@ -2,7 +2,7 @@ local PATH_DATA = vim.fn.stdpath("data") .. "/kubernetes.nvim/"
 local PATH_DEFINITIONS = PATH_DATA .. "definitions.json"
 local PATH_SCHEMA = PATH_DATA .. "schema.json"
 local PATH_YAMLLS_VALIDATION_JS = vim.fn.stdpath("data") ..
-		"/mason/packages/yaml-language-server/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlValidation.js"
+	"/mason/packages/yaml-language-server/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlValidation.js"
 local YAMLLS_PATCH_PATTERN = "isKubernetes && err.message === this.MATCHES_MULTIPLE"
 local YAMLLS_PATH_REPLACEMENT = "err.message === this.MATCHES_MULTIPLE"
 

--- a/lua/kubernetes/init.lua
+++ b/lua/kubernetes/init.lua
@@ -49,18 +49,7 @@ end
 --- returns a list of kinds
 ---@return table
 local function kubectl_kinds()
-	local output = {}
-	local chan = vim.fn.jobstart({ "kubectl", "api-resources", "--no-headers" }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data, _)
-			for i = 1, #data do
-				output[#output + 1] = data[i]
-			end
-		end
-	})
-	if chan <= 0 then error("failed to run kubectl to fetch kinds") end
-	vim.fn.jobwait({ chan })
-	return output
+	return cmd({ "kubectl", "api-resources", "--no-headers" })
 end
 
 --- patches the definitions to include an enum in the `kind` it exists

--- a/lua/kubernetes/init.lua
+++ b/lua/kubernetes/init.lua
@@ -25,7 +25,7 @@ local function kubectl_fetch_definitions()
 	return { definitions = schema["definitions"] }
 end
 
---- returns a list of filetypes
+--- returns a list of kinds
 ---@return table
 local function kubectl_kinds()
 	local output = {}
@@ -130,11 +130,14 @@ function M.yamlls_schema()
 	return "file://" .. PATH_SCHEMA
 end
 
+---@return table containing all valid kube filetypes
 function M.yamlls_filetypes()
 	local filetypes = {}
 	local kinds = kubectl_kinds()
 	for _, k in ipairs(kinds) do
+		-- Grab last column
 		local kind = k:gsub(".* (%w+)$", "%1"):lower()
+
 		table.insert(filetypes, "*." .. kind .. ".yml")
 		table.insert(filetypes, "*." .. kind .. ".yaml")
 	end


### PR DESCRIPTION
NOTE: This currently makes an API call every time you open a file.  It will need to refactored to save the table of filetypes to disk somwhere

This should get rid of `Matches multiple schemas when only one must validate.` for files like `foo.deployment.yaml`.