### PR TITLE
fix: mkdir log outfile dir

### DIFF
--- a/lua/kubernetes/log.lua
+++ b/lua/kubernetes/log.lua
@@ -45,8 +45,10 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
 	config = vim.tbl_deep_extend("force", default_config, config)
 
-	local outfile = string.format('%s/%s/%s.log', vim.api.nvim_call_function('stdpath', { 'data' }), config.plugin,
-		config.plugin)
+	local outfiledir = string.format("%s/%s", vim.api.nvim_call_function("stdpath", { "data" }), config.plugin)
+	vim.fn.mkdir(outfiledir, "p")
+
+	local outfile = string.format("%s/%s.log", outfiledir, config.plugin)
 
 	local obj
 	if standalone then


### PR DESCRIPTION
Fixed a bug that caused the following error if the log directory did not exist.

```
Error executing Lua callback: ...l/share/nvim/lazy/kubernetes.nvim/lua/kubernetes/log.lua:120: attempt to index local 'fp' (a nil value)
```