### PR TITLE
Add 'patch' option, and change yamlls_root to be a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ plugins.
 ```lua
 	{ 'diogo464/kubernetes.nvim' }
         -- or
-	{ 
+	{
           'diogo464/kubernetes.nvim',
           opts = {
             -- this can help with autocomplete. it sets the `additionalProperties` field on type definitions to false if it is not already present.
@@ -25,8 +25,12 @@ plugins.
             -- true:  generate the schema every time the plugin starts
             -- false: only generate the schema if the files don't already exists. run `:KubernetesGenerateSchema` manually to generate the schema if needed.
             schema_generate_always = true,
+            -- Patch yaml-language-server's validation.js file.
+            patch = true,
             -- root path of the yamlls language server. by default it is assumed you are using mason but if not this option allows changing that path.
-	    yamlls_root = vim.fn.stdpath("data") .. "/mason/packages/yaml-language-server/",
+	        yamlls_root = function()
+                    return vim.fs.joinpath(vim.fn.stdpath("data"), "/mason/packages/yaml-language-server/")
+            end
           }
         }
 ```
@@ -96,14 +100,14 @@ them.
 
 So to add support here are the steps:
 
-1. Fetch the all the resource definitions from the cluster.\ 
+1. Fetch the all the resource definitions from the cluster.\
 This can be achieved like so: `kubectl get --raw /openapi/v2 | jq '.definitions'`.
 
-2. Generate a `definitions.json` and `schema.json`.\ 
+2. Generate a `definitions.json` and `schema.json`.\
 The `schema.json` is that `all.json` file that has the `oneOf`.
 To do this just get all iterate the `definitions.json` and add the appropriate entry into `schema.json`. To reference a local file use `file://<full path>#/definitions/...`.
 
-3. Patch the yaml language server.\ 
+3. Patch the yaml language server.\
 Right now kubernetes support seems to be hardcoded into `yamlls`. Trying to use this generated schema without modifications will give out the error `Matches multiple schemas when only one must validate.`. The language server has an check to see if the current document is a kubernetes document and if so then ignore that error.
 ```
 https://github.com/redhat-developer/yaml-language-server/blob/ed03cbf71ade29ea62b4bcac0d8952195fd6969d/src/languageservice/services/yamlValidation.ts#L122

--- a/lua/kubernetes/init.lua
+++ b/lua/kubernetes/init.lua
@@ -9,13 +9,17 @@ local YAMLLS_PATH_REPLACEMENT = "err.message === this.MATCHES_MULTIPLE"
 ---@class Options
 ---@field schema_strict boolean
 ---@field schema_generate_always boolean
----@field yamlls_root string
+---@field patch boolean If false, don't try to patch yaml-language-server.
+---@field yamlls_root function():string
 
 ---@type Options
 local DEFAULT_OPTIONS = {
 	schema_strict = true,
 	schema_generate_always = true,
-	yamlls_root = vim.fn.stdpath("data") .. "/mason/packages/yaml-language-server/",
+        patch = true,
+	yamlls_root = function()
+                return vim.fs.joinpath(vim.fn.stdpath("data"), "mason/packages/yaml-language-server")
+        end
 }
 
 ---@param tbl table
@@ -111,8 +115,9 @@ end
 ---@param opts Options
 ---@return string path yamlls validation js path
 local function yamlls_validation_js_path(opts)
-	return opts.yamlls_root ..
-	"/" .. "node_modules/yaml-language-server/out/server/src/languageservice/services/yamlValidation.js"
+        local root = opts.yamlls_root()
+
+	return vim.fs.joinpath(root, "node_modules/yaml-language-server/out/server/src/languageservice/services/yamlValidation.js")
 end
 
 --- fetches the current cluster's schema using kubectl
@@ -242,7 +247,7 @@ function M.setup(o)
 
 	if M.opts.schema_generate_always or not schema_exists() then
 		schema_generate(M.opts, function()
-			if not yamlls_is_patched(M.opts) then
+			if M.opts.patch and not yamlls_is_patched(M.opts) then
 				yamlls_patch(M.opts)
 				yamlls_restart()
 			end


### PR DESCRIPTION
After a bit of investigation, I realized that I can't have this plugin patch `yaml-language-server` as I use Nix, and the "store" is read-only.

So I can patch in my Nix flake:
```nix
yaml-language-server-patched = pkgs.yaml-language-server.overrideAttrs (oldAttrs: {
    # Apply patch to source before build
    postPatch =
      (oldAttrs.postPatch or "")
      + ''
        # Patch the TypeScript source
        substituteInPlace src/languageservice/services/yamlValidation.ts \
          --replace "if (isKubernetes && err.message === this.MATCHES_MULTIPLE)" \
                    "if (err.message === this.MATCHES_MULTIPLE)"
      '';
  });
```

And then I updated to have a `patch = boolean` option to disable patching completely.

I did make `yamlls_root` a function that returns a string to be more flexible though.